### PR TITLE
Calendar Widget Areas extension

### DIFF
--- a/tribe-ext-calendar-widget-areas/index.php
+++ b/tribe-ext-calendar-widget-areas/index.php
@@ -93,7 +93,7 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 		
 		register_sidebar (
 			array (
-				'name'			=> __( 'TEC Above Calendar AND Single Events', 'tribe-extension' ),
+				'name'			=> __( 'TEC Above Single Events', 'tribe-extension' ),
 				'id'			=> 'tec_ext_cal_widget_areas_single__before_view',
 				'description'	=> __( 'Widgets in this area will be shown ABOVE Event Single pages.', 'tribe-extension' ),
 			)
@@ -101,7 +101,7 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 		
 		register_sidebar (
 			array (
-				'name'			=> __( 'TEC Below Calendar AND Single Events', 'tribe-extension' ),
+				'name'			=> __( 'TEC Below Single Events', 'tribe-extension' ),
 				'id'			=> 'tec_ext_cal_widget_areas_single__after_view',
 				'description'	=> __( 'Widgets in this area will be shown BELOW Event Single pages.', 'tribe-extension' ),
 			)
@@ -136,6 +136,10 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	 * @access: public
 	 */
 	public function before_view() {
+		if ( ! tribe_is_event() ) {
+			return false;
+		}
+		
 		dynamic_sidebar( 'tec_ext_cal_widget_areas_single__before_view' );
 	}
 	
@@ -146,6 +150,10 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	 * @access: public
 	 */
 	public function after_view() {
+		if ( ! tribe_is_event() ) {
+			return false;
+		}
+		
 		dynamic_sidebar( 'tec_ext_cal_widget_areas_single__after_view' );
 	}
 	

--- a/tribe-ext-calendar-widget-areas/index.php
+++ b/tribe-ext-calendar-widget-areas/index.php
@@ -11,7 +11,7 @@
 */
 
 // Created 2015-10-05 for https://theeventscalendar.com/support/forums/topic/control-visibility-of-sidebar-widgets/#dl_post-1011743
-// Turned into an Extension by Cliff on 2016-12-14
+// Turned into an Extension by Cliff on 2016-12-23
 
 // Do not load directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -33,6 +33,13 @@ if ( ! function_exists( 'dynamic_sidebar' ) ) {
 */
 class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	/**
+	 * Option key for which widget areas are enabled
+	 *
+	 * @var string
+	 */
+	protected $option_key_enabled_areas = 'tribe_ext_enabled_widget_areas';
+
+	/**
 	 * Setup the Extension's properties.
 	 *
 	 * This always executes even if the required plugins are not present.
@@ -48,6 +55,140 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	}
 	
 	/**
+	 * All available widget areas this extension supports and details about each in a multidimensional associative array.
+	 *
+	 * Follow this format to enable a new widget area for each action hook you want
+	 * to use. You will also need to add an additional method toward the end of this
+	 * file for each area added so we know what code to execute.
+	 * 
+	 * @access: public
+	 * @return: array
+	 */
+	public function get_all_areas() {
+		// format is:
+		// action_hook => array of details what to do if we use this hook
+		$areas = array(
+			'tribe_events_before_template'	=>	array(
+				'method'  	=> 'before_template',
+				'name'		=> __( 'TEC Above Calendar', 'tribe-extension' ),
+				'desc'		=> __( 'Widgets in this area will be shown ABOVE The Events Calendar.', 'tribe-extension' ),
+			),				
+			'tribe_events_after_template'	=>	array(
+				'method'  	=> 'after_template',
+				'name'		=> __( 'TEC Below Calendar', 'tribe-extension' ),
+				'desc'		=> __( 'Widgets in this area will be shown BELOW The Events Calendar.', 'tribe-extension' ),
+			),				
+			'tribe_events_before_view'	=>	array(
+				'method'  	=> 'before_view',
+				'name'		=> __( 'TEC Above Single Events', 'tribe-extension' ),
+				'desc'		=> __( 'Widgets in this area will be shown ABOVE Single Events.', 'tribe-extension' ),
+			),				
+			'tribe_events_after_view'	=>	array(
+				'method'  	=> 'after_view',
+				'name'		=> __( 'TEC Above Single Events', 'tribe-extension' ),
+				'desc'		=> __( 'Widgets in this area will be shown BELOW Single Events.', 'tribe-extension' ),
+			),
+		);
+		
+		return $areas;
+	}
+	
+	/**
+	 * Build options to present to user
+	 * 
+	 * @access: public
+	 * @return: array
+	 */
+	public function get_available_area_options() {
+		$options = array();
+		
+		foreach ( $this->get_all_areas() as $key => $value ) {
+			$options[$key] = $value['name'];
+		}
+		
+		return $options;
+	}
+	
+	/**
+	 * The chosen widget areas to activate/run.
+	 * 
+	 * @access: public
+	 * @return: array
+	 */
+	public function get_enabled_areas_simple() {
+		$all_available = $this->get_all_areas();
+		
+		$enabled_areas = tribe_get_option( $this->option_key_enabled_areas, $all_available );
+		
+		if ( is_array( $enabled_areas ) ) {
+			foreach ( $enabled_areas as $key => $value ) {
+				if ( ! array_key_exists( $value, $all_available ) ) {
+					unset( $enabled_areas[$key] );
+				}
+			}
+		}
+		
+		return $enabled_areas;
+	}
+		
+	/**
+	 * The chosen widget areas to activate/run.
+	 * 
+	 * @access: public
+	 * @return: array
+	 */
+	public function get_enabled_areas_full_details() {
+		$all_available = $this->get_all_areas();
+		
+		$enabled_areas = $this->get_enabled_areas_simple();
+		
+		$return = array();
+		
+		if ( is_array( $enabled_areas ) ) {
+			foreach ( $enabled_areas as $key => $value ) {
+				if ( array_key_exists( $value, $all_available ) ) {
+					$return[$value] = $all_available[$value];
+				}
+			}
+		}
+		
+		// if none selected, return all available
+		if ( empty( $enabled_areas ) || ! is_array( $enabled_areas ) ) {
+			$return = $all_available;
+		}
+		
+		return $return;
+	}
+	
+	/**
+	 * Add options to Tribe settings page
+	 *
+	 * @access: public
+	 */
+	public function add_settings() {
+		require_once dirname( __FILE__ ) . '/src/Tribe/Settings_Helper.php';
+
+		// Setup fields on the settings page
+		$setting_helper = new Tribe__Extension__Settings_Helper();
+		$options = $this->get_available_area_options();
+
+		$setting_helper->add_field(
+			$this->option_key_enabled_areas,
+			array(
+				'type'            => 'checkbox_list',
+				'label'           => esc_html__( 'Widget Areas', 'tribe-extension' ),
+				'tooltip'         => esc_html__( 'Select which widget areas you want available on your site.', 'tribe-extension' ),
+				'default'         => array_keys( $options ),
+				'validation_type' => 'options_multi',
+				'options'         => $options,
+			),
+			'display',
+			'tribeEventsBeforeHTML',
+			true
+		);
+	}
+	
+	/**
 	 * Extension initialization and hooks.
 	 * 
 	 * @access: public
@@ -56,17 +197,17 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 		// Register all widget areas
 		add_action( 'widgets_init', array( $this, 'register_sidebars' ) );
 		
-		// Print "Before Calendar" Widget Area
-		add_action( 'tribe_events_before_template', array( $this, 'before_template' ) );
+		add_action( 'admin_init', array( $this, 'add_settings' ) );
 		
-		// Print "After Calendar" Widget Area
-		add_action( 'tribe_events_after_template', array( $this, 'after_template' ) );
+		$active_areas = $this->get_enabled_areas_full_details();
 		
-		// Print "Before Calendar and Event Single" Widget Area
-		add_action( 'tribe_events_before_view', array( $this, 'before_view' ) );
-		
-		// Print "After Calendar and Event Single" Widget Area
-		add_action( 'tribe_events_after_view', array( $this, 'after_view' ) );
+		foreach ( $active_areas as $key => $value ) {
+			$method = '';
+			$method = $value['method'];
+			if ( method_exists( $this, $method ) ) {
+				add_action( $key, array( $this, $method ) );
+			}
+		}
 	}
 	
 	/**
@@ -75,38 +216,17 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	 * @access: public
 	 */
 	public function register_sidebars() {
-		register_sidebar (
-			array (
-				'name'			=> __( 'TEC Above Calendar', 'tribe-extension' ),
-				'id'			=> 'tec_ext_cal_widget_areas__before_template',
-				'description'	=> __( 'Widgets in this area will be shown ABOVE The Events Calendar.', 'tribe-extension' ),
-			)
-		);
+		$active_areas = $this->get_enabled_areas_full_details();
 		
-		register_sidebar (
-			array (
-				'name'			=> __( 'TEC Below Calendar', 'tribe-extension' ),
-				'id'			=> 'tec_ext_cal_widget_areas__after_template',
-				'description'	=> __( 'Widgets in this area will be shown BELOW The Events Calendar.', 'tribe-extension' ),
-			)
-		);
-		
-		register_sidebar (
-			array (
-				'name'			=> __( 'TEC Above Single Events', 'tribe-extension' ),
-				'id'			=> 'tec_ext_cal_widget_areas_single__before_view',
-				'description'	=> __( 'Widgets in this area will be shown ABOVE Event Single pages.', 'tribe-extension' ),
-			)
-		);
-		
-		register_sidebar (
-			array (
-				'name'			=> __( 'TEC Below Single Events', 'tribe-extension' ),
-				'id'			=> 'tec_ext_cal_widget_areas_single__after_view',
-				'description'	=> __( 'Widgets in this area will be shown BELOW Event Single pages.', 'tribe-extension' ),
-			)
-		);
-	
+		foreach ( $active_areas as $key => $value ) {
+			register_sidebar (
+				array (
+					'name'			=> $value['name'],
+					'id'			=> "tec_ext_cal_widget_areas__{$value['method']}",
+					'description'	=> $value['desc'],
+				)
+			);
+		}	
 	}
 	
 	
@@ -131,7 +251,7 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	
 	
 	/**
-	 * "Before Calendar and Event Single" Widget Area
+	 * "Before Event Single" Widget Area
 	 * 
 	 * @access: public
 	 */
@@ -145,7 +265,7 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	
 	
 	/**
-	 * "After Calendar and Event Single" Widget Area
+	 * "After Event Single" Widget Area
 	 * 
 	 * @access: public
 	 */

--- a/tribe-ext-calendar-widget-areas/index.php
+++ b/tribe-ext-calendar-widget-areas/index.php
@@ -1,0 +1,152 @@
+<?php
+/**
+* Plugin Name: The Events Calendar Extension: Calendar Widget Areas
+* Description: Adds widget areas (a.k.a. sidebars) that only display on The Events Calendar pages/views
+* Version: 1.0
+* Extension Class: Tribe__Extension__Calendar_Widget_Areas
+* Author: Modern Tribe, Inc.
+* Author URI: http://m.tri.be/1971
+* License: GPLv2 or later
+* License URI: https://www.gnu.org/licenses/gpl-2.0.html
+*/
+
+// Created 2015-10-05 for https://theeventscalendar.com/support/forums/topic/control-visibility-of-sidebar-widgets/#dl_post-1011743
+// Turned into an Extension by Cliff on 2016-12-14
+
+// Do not load directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( '-1' );
+}
+
+// Do not load unless Tribe Common is fully loaded.
+if ( ! class_exists( 'Tribe__Extension' ) ) {
+	return;
+}
+
+// Do not load unless dynamic_sidebar exists -- since WP 2.2.0, per https://developer.wordpress.org/reference/functions/dynamic_sidebar/
+if ( ! function_exists( 'dynamic_sidebar' ) ) {
+	return;
+}
+
+/**
+* Extension main class, class begins loading on init() function.
+*/
+class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
+	/**
+	 * Setup the Extension's properties.
+	 *
+	 * This always executes even if the required plugins are not present.
+	 * 
+	 * @access: public
+	 */
+	public function construct() {
+		// Each plugin required by this extension
+		$this->add_required_plugin( 'Tribe__Events__Main' );
+				
+		// Set the extension's TEC URL
+		$this->set_url( 'https://theeventscalendar.com/extensions/calendar-widget-areas/' );
+	}
+	
+	/**
+	 * Extension initialization and hooks.
+	 * 
+	 * @access: public
+	 */
+	public function init() {
+		// Register all widget areas
+		add_action( 'widgets_init', array( $this, 'register_sidebars' ) );
+		
+		// Print "Before Calendar" Widget Area
+		add_action( 'tribe_events_before_template', array( $this, 'before_template' ) );
+		
+		// Print "After Calendar" Widget Area
+		add_action( 'tribe_events_after_template', array( $this, 'after_template' ) );
+		
+		// Print "Before Calendar and Event Single" Widget Area
+		add_action( 'tribe_events_before_view', array( $this, 'before_view' ) );
+		
+		// Print "After Calendar and Event Single" Widget Area
+		add_action( 'tribe_events_after_view', array( $this, 'after_view' ) );
+	}
+	
+	/**
+	 * Register all widget areas.
+	 * 
+	 * @access: public
+	 */
+	public function register_sidebars() {
+		register_sidebar (
+			array (
+				'name'			=> __( 'TEC Above Calendar', 'tribe-extension' ),
+				'id'			=> 'tec_ext_cal_widget_areas__before_template',
+				'description'	=> __( 'Widgets in this area will be shown ABOVE The Events Calendar.', 'tribe-extension' ),
+			)
+		);
+		
+		register_sidebar (
+			array (
+				'name'			=> __( 'TEC Below Calendar', 'tribe-extension' ),
+				'id'			=> 'tec_ext_cal_widget_areas__after_template',
+				'description'	=> __( 'Widgets in this area will be shown BELOW The Events Calendar.', 'tribe-extension' ),
+			)
+		);
+		
+		register_sidebar (
+			array (
+				'name'			=> __( 'TEC Above Calendar AND Single Events', 'tribe-extension' ),
+				'id'			=> 'tec_ext_cal_widget_areas_single__before_view',
+				'description'	=> __( 'Widgets in this area will be shown ABOVE Event Single pages.', 'tribe-extension' ),
+			)
+		);
+		
+		register_sidebar (
+			array (
+				'name'			=> __( 'TEC Below Calendar AND Single Events', 'tribe-extension' ),
+				'id'			=> 'tec_ext_cal_widget_areas_single__after_view',
+				'description'	=> __( 'Widgets in this area will be shown BELOW Event Single pages.', 'tribe-extension' ),
+			)
+		);
+	
+	}
+	
+	
+	/**
+	 * "Before Calendar" Widget Area
+	 * 
+	 * @access: public
+	 */
+	public function before_template() {
+		dynamic_sidebar( 'tec_ext_cal_widget_areas__before_template' );
+	}
+	
+	
+	/**
+	 * "After Calendar" Widget Area
+	 * 
+	 * @access: public
+	 */
+	public function after_template() {
+		dynamic_sidebar( 'tec_ext_cal_widget_areas__after_template' );
+	}
+	
+	
+	/**
+	 * "Before Calendar and Event Single" Widget Area
+	 * 
+	 * @access: public
+	 */
+	public function before_view() {
+		dynamic_sidebar( 'tec_ext_cal_widget_areas_single__before_view' );
+	}
+	
+	
+	/**
+	 * "After Calendar and Event Single" Widget Area
+	 * 
+	 * @access: public
+	 */
+	public function after_view() {
+		dynamic_sidebar( 'tec_ext_cal_widget_areas_single__after_view' );
+	}
+	
+}

--- a/tribe-ext-calendar-widget-areas/index.php
+++ b/tribe-ext-calendar-widget-areas/index.php
@@ -1,7 +1,7 @@
 <?php
 /**
 * Plugin Name: The Events Calendar Extension: Calendar Widget Areas
-* Description: Adds widget areas (a.k.a. sidebars) that only display on The Events Calendar pages/views
+* Description: Adds widget areas (a.k.a. sidebars) that only display on The Events Calendar pages/views. Areas may be enabled or disabled in the Display tab of Events Settings.
 * Version: 1.0
 * Extension Class: Tribe__Extension__Calendar_Widget_Areas
 * Author: Modern Tribe, Inc.

--- a/tribe-ext-calendar-widget-areas/index.php
+++ b/tribe-ext-calendar-widget-areas/index.php
@@ -90,7 +90,7 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 			),
 		);
 		
-		return $areas;
+		return apply_filters( 'tribe_ext_calendar_widget_areas', $areas );
 	}
 	
 	/**

--- a/tribe-ext-calendar-widget-areas/index.php
+++ b/tribe-ext-calendar-widget-areas/index.php
@@ -52,18 +52,24 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	/**
 	 * All available widget areas this extension supports and details about each in a multidimensional associative array.
 	 *
-	 * Follow this format to enable a new widget area for each action hook you want
-	 * to use. You will also need to add an additional method toward the end of this
-	 * file for each area added so we know what code to execute.
+	 * Follow this format to enable a new widget area for each action or filter hook
+	 * you want to use. You will also need to add an additional method toward the 
+	 * end of this file for each area added so we know what code to execute.
 	 * 
-	 * @return array
+	 * @return array {
+	 *     Every widget area supported by this extension
+	 * 
+	 *     @param array $hook {
+	 *         The details for each widget area
+	 * 
+	 *         @param string $method	The method of this class that outputs the widget. This value may prefix with context, such as "single_", and the actual function named accordingly and having the necessary logic in place. The actual function names are "tec_ext_widget_areas__" + the 'method' name from here.
+	 *         @param string $name		Name of the widget in the admin screens
+	 *         @param string $desc		Widget description
+	 *         @param string $filter	If $hook is a 'filter' hook instead of an action hook, set this to (bool) true.
+	 *     }
+	 * }
 	 */
 	public function get_all_areas() {
-		// format is:
-		// action_hook => array of details what to do if we use this hook
-		// 'method' value may lead with context, such as "single_" and the actual function named accordingly and having the necessary logic in place
-		// actual function names are "tec_ext_widget_areas__" + the 'method' name from here
-		// optional 'hook_type' => 'action' or 'filter' to tell init() add_action or add_filter -- will default to add_action
 		$areas = array(
 			'tribe_events_before_template'	=>	array(
 				'method'  	=> 'before_template',
@@ -194,7 +200,7 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 			$method = $value['method'];
 			if ( method_exists( $this, $method ) ) {
 				// add_filter or add_action
-				if ( ! empty( $value['hook_type'] ) && 'filter' === $value['hook_type'] ) {
+				if ( ! empty( $value['filter'] ) && true === $value['filter'] ) {
 					add_filter( $key, array( $this, $method ) );
 				} else {
 					add_action( $key, array( $this, $method ) );
@@ -241,7 +247,7 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	 * "Before Event Single" Widget Area
 	 */
 	public function single_before_view() {
-		if ( ! tribe_is_event() ) {
+		if ( ! is_singular( Tribe__Events__Main::POSTTYPE ) ) {
 			return false;
 		}
 		
@@ -253,7 +259,7 @@ class Tribe__Extension__Calendar_Widget_Areas extends Tribe__Extension {
 	 * "After Event Single" Widget Area
 	 */
 	public function single_after_view() {
-		if ( ! tribe_is_event() ) {
+		if ( ! is_singular( Tribe__Events__Main::POSTTYPE ) ) {
 			return false;
 		}
 		

--- a/tribe-ext-calendar-widget-areas/src/Tribe/Settings_Helper.php
+++ b/tribe-ext-calendar-widget-areas/src/Tribe/Settings_Helper.php
@@ -1,0 +1,232 @@
+<?php
+
+// Do not load directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( '-1' );
+}
+
+if ( class_exists( 'Tribe__Extension__Settings_Helper' ) ) {
+	return;
+}
+
+/**
+ * Helper for inserting/removing fields on the WP Admin Tribe Settings pages
+ */
+class Tribe__Extension__Settings_Helper {
+
+	/**
+	 * Fields inserted into misc section
+	 *
+	 * @var array
+	 */
+	private $insert_fields_misc = array();
+
+	/**
+	 * Fields that will be inserted above a specified field
+	 *
+	 * @var array
+	 */
+	private $insert_fields_above = array();
+
+	/**
+	 * Fields that will be inserted below a specified field
+	 *
+	 * @var array
+	 */
+	private $insert_fields_below = array();
+
+	/**
+	 * Array of settings being added to a Tribe Settings tab
+	 *
+	 * @var array
+	 */
+	private $remove_fields = array();
+
+
+	/**
+	 * Setup the helper
+	 *
+	 * @param int $priority Priority at which this hooks into 'tribe_settings_tab_fields'.
+	 */
+	public function __construct( $priority = 100 ) {
+		add_filter( 'tribe_settings_tab_fields', array( $this, 'filter_options' ), $priority, 2 );
+	}
+
+
+	/**
+	 * Add a field to a Tribe Settings tab
+	 *
+	 * @param string $field_key         Option key for your setting. Example: 'fancyOptionName'.
+	 * @param array $field_args         See Tribe__Field() for available args.
+	 *                                  Example: array( 'type' => 'checkbox_bool, 'label' => ... )
+	 * @param string $setting_tab       Settings tab where this will be added. Example: 'display'.
+	 * @param string $neighboring_field (optional) The field key/HTML name="" attribute to insert this under.
+	 * @param bool   $above             (optional) Insert above or below its neighbor.
+	 */
+	public function add_field( $field_key, $field_args, $setting_tab, $neighboring_field = null, $above = true ) {
+		// Our settings walker needs 'key' => arg pairs.
+		$field = array( $field_key => $field_args );
+
+		$this->add_fields( $field, $setting_tab, $neighboring_field, $above );
+	}
+
+	/**
+	 * Add multiple fields to a Tribe Settings tab
+	 *
+	 * @param array  $fields            Fields that will be added, expects 'fieldname' => (array) args.
+	 * @param string $setting_tab       Settings tab where this will be added. Example: 'display'.
+	 * @param string $neighboring_field (optional) The field key/HTML name="" attribute to insert this under.
+	 * @param bool   $above             (optional) Insert above or below its neighbor.
+	 */
+	public function add_fields( $fields, $setting_tab, $neighboring_field = null, $above = false ) {
+
+		foreach ( $fields as $key => $val ) {
+			// Handles button_link type that doesn't exist in Tribe__Field.
+			if ( 'button_link' === $fields[ $key ]['type'] ) {
+				$fields[ $key ]['type'] = 'html';
+				$fields[ $key ]['html'] = $this->get_button_html(
+					$key,
+					$fields[ $key ]['label'],
+					$fields[ $key ]['url'],
+					$fields[ $key ]['tooltip']
+				);
+				unset( $fields[ $key ]['label'] );
+				unset( $fields[ $key ]['tooltip'] );
+			}
+		}
+
+		if ( ! is_string( $neighboring_field ) ) {
+			// If neighbor is not specified, add this to misc section.
+			$this->insert_fields_misc = array_replace_recursive(
+				$this->insert_fields_misc,
+				array( $setting_tab => $fields )
+			);
+		} elseif ( true === $above ) {
+			// Add to above fields list with neighbor specified.
+			$this->insert_fields_above = array_replace_recursive(
+				$this->insert_fields_above,
+				array( $setting_tab => array( $neighboring_field => $fields ) )
+			);
+		} else {
+			// Add to below fields list with neighbor specified.
+			$this->insert_fields_below = array_replace_recursive(
+				$this->insert_fields_below,
+				array( $setting_tab => array( $neighboring_field => $fields ) )
+			);
+		}
+
+	}
+
+
+	/**
+	 * Remove a field from one of the tabs in WP Admin > Events > Settings
+	 *
+	 * @param string $field_key   Option key for your setting. Example: 'fancyOptionName'.
+	 * @param string $setting_tab Settings tab where this will be added. Example: 'display'.
+	 */
+	public function remove_field( $field_key, $setting_tab ) {
+		$this->remove_fields[ $setting_tab ][] = $field_key;
+	}
+
+
+	/**
+	 * Attached to 'tribe_settings_tab_fields' to add/remove this class' fields on Tribe Settings pages.
+	 *
+	 * @param array $fields The fields within tribe settings page.
+	 * @param string $tab   The settings tab key.
+	 *
+	 * @return array $fields The fields within tribe settings page
+	 */
+	public function filter_options( $fields, $tab ) {
+
+		// Fields appended to misc section.
+		if ( array_key_exists( $tab, $this->insert_fields_misc ) ) {
+
+			// Add a misc heading if none exists.
+			if ( ! array_key_exists( 'tribeMiscSettings', $fields ) ) {
+				$misc_heading = array(
+					'tribeMiscSettings' => array(
+						'type' => 'html',
+						'html' => '<h3>' . esc_html__( 'Miscellaneous Settings', 'tribe-common' ) . '</h3>',
+					),
+				);
+				$fields = Tribe__Main::array_insert_before_key( 'tribe-form-content-end', $fields, $misc_heading );
+			}
+
+			// Insert these settings under misc heading.
+			$fields = Tribe__Main::array_insert_after_key( 'tribeMiscSettings', $fields, $this->insert_fields_misc[ $tab ] );
+		}
+
+		// Fields inserted above a neighboring field.
+		if ( array_key_exists( $tab, $this->insert_fields_above ) ) {
+
+			foreach ( $this->insert_fields_above[ $tab ] as $insert_after => $new_field ) {
+				$fields = Tribe__Main::array_insert_before_key( $insert_after, $fields, $new_field );
+			}
+		}
+
+		// Fields inserted below a neighboring field.
+		if ( array_key_exists( $tab, $this->insert_fields_below ) ) {
+
+			foreach ( $this->insert_fields_below[ $tab ] as $insert_after => $new_field ) {
+				$fields = Tribe__Main::array_insert_after_key( $insert_after, $fields, $new_field );
+			}
+		}
+
+		// Fields that will be removed.
+		if ( array_key_exists( $tab, $this->remove_fields ) ) {
+
+			foreach ( $this->remove_fields[ $tab ] as $remove_field ) {
+				if ( array_key_exists( $remove_field, $fields ) ) {
+					unset( $fields[ $remove_field ] );
+				}
+			}
+		}
+
+		return $fields;
+	}
+
+
+
+	/**
+	 * Builds a button/link to add to the setting page, mimicing those in The Events Calendar
+	 *
+	 * @param string $slug    The field slug
+	 * @param string $label   The label for the button and field
+	 * @param string $url     The link element URL
+	 * @param string $tooltip Optional paragraph to appear underneath link
+	 *
+	 * @return string The button HTML
+	 */
+	protected function get_button_html( $slug, $label, $url, $tooltip = '' ) {
+		$legend = sprintf(
+			'<legend class="tribe-field-label">%s</legend>',
+			$label
+		);
+
+		if ( ! empty( $tooltip ) ) {
+			$tooltip = sprintf(
+				'<p class="tribe-field-indent description">%s</p>',
+				$tooltip
+			);
+		}
+
+		$field_wrap = sprintf(
+			'<div class="tribe-field-wrap"><a href="%1$s" class="button">%2$s</a>%3$s</div>',
+			$url,
+			$label,
+			$tooltip
+		);
+
+		$output = sprintf(
+			'<fieldset id="tribe-field-%1$s" class="tribe-field tribe-field-button_link">%2$s%3$s</fieldset><div class="clear"></div>',
+			$slug,
+			$legend,
+			$field_wrap
+		);
+
+		return $output;
+	}
+
+}
+


### PR DESCRIPTION
https://central.tri.be/issues/69302

Adds widget areas (a.k.a. sidebars) that only display on The Events Calendar pages/views

See https://theeventscalendar.com/support/forums/topic/control-visibility-of-sidebar-widgets/#dl_post-1011743 for existing screenshots