### PR TITLE
Fixed 3 small bugs Zach found

### DIFF
--- a/tribe-ext-dequeue-assets/index.php
+++ b/tribe-ext-dequeue-assets/index.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Tribe Extension: Dequeque Assets
  * Description: Dequeues any scripts or styles that are registered using the tribe_asset() function. Adds a list of dequeueable assets to WP Admin > Events > Settings.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Extension Class: Tribe__Extension__Dequeue_Assets
  * Author: Modern Tribe, Inc.
  * Author URI: http://m.tri.be/1971

--- a/tribe-ext-dequeue-assets/src/Tribe/Settings_Helper.php
+++ b/tribe-ext-dequeue-assets/src/Tribe/Settings_Helper.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-if ( class_exists( 'Tribe__Settings_Helper' ) ) {
+if ( class_exists( 'Tribe__Extension__Settings_Helper' ) ) {
 	return;
 }
 

--- a/tribe-ext-link-events-back-to-facebook/index.php
+++ b/tribe-ext-link-events-back-to-facebook/index.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     The Events Calendar Extension: Link Events Back to Facebook
  * Description:     An extension that makes event titles link to the events' Website URLs when present.
- * Version:         1.0.0
+ * Version:         1.0.1
  * Extension Class: Tribe__Extension_Link_Events_Back_to_FB
  * Author:          Modern Tribe, Inc.
  * Author URI:      http://m.tri.be/1971
@@ -27,8 +27,7 @@ class Tribe__Extension_Link_Events_Back_to_FB extends Tribe__Extension {
 	 *
 	 */
 	public function construct() {
-		$this->add_required_plugin( 'Tribe__Events__Main', '4.0' );
-		$this->add_required_plugin( 'Tribe__Events__Facebook__Importer' );
+		$this->add_required_plugin( 'Tribe__Events__Main' );
 		$this->set_url( 'https://theeventscalendar.com/extensions/add-the-source-link-of-an-event-imported-from-facebook/' );
 	}
 
@@ -43,14 +42,17 @@ class Tribe__Extension_Link_Events_Back_to_FB extends Tribe__Extension {
 	 * Add a link to the Facebook event at the start of event content.
 	 */
 	public function add_link_to_fb_event() {
-	  
 		$fbid = tribe_get_event_meta( get_the_ID(), '_FacebookID' );
-		
+
 		// Only proceed if this event is indeed imported from Facebook.
 		if ( empty( $fbid ) ) {
 			return;
 		}
 
-		printf( '<p><a href="http://facebook.com/events/%2%s" target="_blank" rel="nofollow">%1$s</a></p>', esc_html__( 'See this event on Facebook', 'tribe-extension' ), absint( $fbid ) );
+		printf(
+			'<p><a href="http://facebook.com/events/%2%s" target="_blank" rel="nofollow">%1$s</a></p>',
+			esc_html__( 'See this event on Facebook', 'tribe-extension' ),
+			$fbid
+		);
 	}
 }

--- a/tribe-ext-selectively-show-html/index.php
+++ b/tribe-ext-selectively-show-html/index.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     The Events Calendar Extension: Selectively Show HTML Boxes
  * Description:     Adds fields to WP Admin > Events > Settings > Display for selecting which views to see the HTML Before/After content on. This allows you to show these boxes on views of your choosing.
- * Version:         1.0.0
+ * Version:         1.0.1
  * Extension Class: Tribe__Extension__Selectively_Show_HTML
  * Author:          Modern Tribe, Inc.
  * Author URI:      http://m.tri.be/1971
@@ -55,7 +55,7 @@ class Tribe__Extension__Selectively_Show_HTML extends Tribe__Extension {
 	public function add_settings() {
 		require_once dirname( __FILE__ ) . '/src/Tribe/Settings_Helper.php';
 
-		$avail_views = Tribe__View_Helper::get_available_views();
+		$avail_views = Tribe__Extension__View_Helper::get_available_views();
 		$field_view_options = array();
 
 		foreach ( $avail_views as $slug => $view ) {
@@ -63,7 +63,7 @@ class Tribe__Extension__Selectively_Show_HTML extends Tribe__Extension {
 		}
 
 		// Setup fields on the settings page
-		$setting_helper = new Tribe__Settings_Helper();
+		$setting_helper = new Tribe__Extension__Settings_Helper();
 
 		$setting_helper->add_field(
 			'show_html_before_views',
@@ -126,7 +126,7 @@ class Tribe__Extension__Selectively_Show_HTML extends Tribe__Extension {
 	public function hide_views_htmls( $html, $option_key ) {
 		$visible_views = tribe_get_option( $option_key, array() );
 
-		if ( ! Tribe__View_Helper::is_view( $visible_views ) ) {
+		if ( ! Tribe__Extension__View_Helper::is_view( $visible_views ) ) {
 			$html = '';
 		}
 

--- a/tribe-ext-selectively-show-html/src/Tribe/Settings_Helper.php
+++ b/tribe-ext-selectively-show-html/src/Tribe/Settings_Helper.php
@@ -5,14 +5,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-if ( class_exists( 'Tribe__Settings_Helper' ) ) {
+if ( class_exists( 'Tribe__Extension__Settings_Helper' ) ) {
 	return;
 }
 
 /**
  * Helper for inserting/removing fields on the WP Admin Tribe Settings pages
  */
-class Tribe__Settings_Helper {
+class Tribe__Extension__Settings_Helper {
 
 	/**
 	 * Fields inserted into misc section
@@ -79,6 +79,22 @@ class Tribe__Settings_Helper {
 	 * @param bool   $above             (optional) Insert above or below its neighbor.
 	 */
 	public function add_fields( $fields, $setting_tab, $neighboring_field = null, $above = false ) {
+
+		foreach ( $fields as $key => $val ) {
+			// Handles button_link type that doesn't exist in Tribe__Field.
+			if ( 'button_link' === $fields[ $key ]['type'] ) {
+				$fields[ $key ]['type'] = 'html';
+				$fields[ $key ]['html'] = $this->get_button_html(
+					$key,
+					$fields[ $key ]['label'],
+					$fields[ $key ]['url'],
+					$fields[ $key ]['tooltip']
+				);
+				unset( $fields[ $key ]['label'] );
+				unset( $fields[ $key ]['tooltip'] );
+			}
+		}
+
 		if ( ! is_string( $neighboring_field ) ) {
 			// If neighbor is not specified, add this to misc section.
 			$this->insert_fields_misc = array_replace_recursive(
@@ -170,5 +186,46 @@ class Tribe__Settings_Helper {
 		return $fields;
 	}
 
-}
 
+
+	/**
+	 * Builds a button/link to add to the setting page, mimicing those in The Events Calendar
+	 *
+	 * @param string $slug    The field slug
+	 * @param string $label   The label for the button and field
+	 * @param string $url     The link element URL
+	 * @param string $tooltip Optional paragraph to appear underneath link
+	 *
+	 * @return string The button HTML
+	 */
+	protected function get_button_html( $slug, $label, $url, $tooltip = '' ) {
+		$legend = sprintf(
+			'<legend class="tribe-field-label">%s</legend>',
+			$label
+		);
+
+		if ( ! empty( $tooltip ) ) {
+			$tooltip = sprintf(
+				'<p class="tribe-field-indent description">%s</p>',
+				$tooltip
+			);
+		}
+
+		$field_wrap = sprintf(
+			'<div class="tribe-field-wrap"><a href="%1$s" class="button">%2$s</a>%3$s</div>',
+			$url,
+			$label,
+			$tooltip
+		);
+
+		$output = sprintf(
+			'<fieldset id="tribe-field-%1$s" class="tribe-field tribe-field-button_link">%2$s%3$s</fieldset><div class="clear"></div>',
+			$slug,
+			$legend,
+			$field_wrap
+		);
+
+		return $output;
+	}
+
+}

--- a/tribe-ext-selectively-show-html/src/Tribe/View_Helper.php
+++ b/tribe-ext-selectively-show-html/src/Tribe/View_Helper.php
@@ -5,11 +5,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-if ( ! class_exists( 'Tribe__View_Helper' ) ) {
+if ( class_exists( 'Tribe__Extension__View_Helper' ) ) {
 	return;
 }
 /**
- * Class Tribe__View_Helper
+ * Class Tribe__Extension__View_Helper
  *
  * @todo This class is old, it will be massively redone with the new view architecture in 4.5 then integrated into Core. Until then it works.
  *
@@ -19,7 +19,7 @@ if ( ! class_exists( 'Tribe__View_Helper' ) ) {
  * - Determining which view is currently displaying
  */
 
-class Tribe__View_Helper {
+class Tribe__Extension__View_Helper {
 
 	/**
 	 * A list of views this class can help with, each item can contain:


### PR DESCRIPTION
Zach found some small bugs in three extensions:

Dequeue Assets - Wouldn't add settings if other extensions were active that added their own extensions

Link FB events - Can't reliably absint a FBID, no need for it anyways. This plugin does not require the old FB importer plugin.

Selectively show HTML - View Helper class wouldn't load. Updated the Settings_Helper while I was in there to use the latest version and name.